### PR TITLE
Allow acl adapters

### DIFF
--- a/src/Auth/AclAdapter/AclAdapterInterface.php
+++ b/src/Auth/AclAdapter/AclAdapterInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TinyAuth\Auth\AclAdapter;
+
+interface AclAdapterInterface
+{
+    /**
+     * Generates and returns a TinyAuth access control list.
+     *
+     * @param array $availableRoles A list of available user roles.
+     * @param array $tinyConfig Current TinyAuth configuration values.
+     *
+     * @return array
+     */
+    public function getAcl($availableRoles, $tinyConfig);
+}

--- a/src/Auth/AclAdapter/IniAclAdapter.php
+++ b/src/Auth/AclAdapter/IniAclAdapter.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace TinyAuth\Auth\AclAdapter;
+
+use TinyAuth\Utility\Utility;
+
+class IniAclAdapter implements AclAdapterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getAcl($availableRoles, $tinyConfig)
+    {
+        $iniArray = Utility::parseFiles($tinyConfig['filePath'], $tinyConfig['file']);
+
+        $res = [];
+        foreach ($iniArray as $key => $array) {
+            $res[$key] = Utility::deconstructIniKey($key);
+            $res[$key]['map'] = $array;
+
+            foreach ($array as $actions => $roles) {
+                // Get all roles used in the current INI section
+                $roles = explode(',', $roles);
+                $actions = explode(',', $actions);
+
+                foreach ($roles as $roleId => $role) {
+                    $role = trim($role);
+                    if (!$role) {
+                        continue;
+                    }
+                    // Prevent undefined roles appearing in the iniMap
+                    if (!array_key_exists($role, $availableRoles) && $role !== '*') {
+                        unset($roles[$roleId]);
+                        continue;
+                    }
+                    if ($role === '*') {
+                        unset($roles[$roleId]);
+                        $roles = array_merge($roles, array_keys($availableRoles));
+                    }
+                }
+
+                foreach ($actions as $action) {
+                    $action = trim($action);
+                    if (!$action) {
+                        continue;
+                    }
+
+                    foreach ($roles as $role) {
+                        $role = trim($role);
+                        if (!$role || $role === '*') {
+                            continue;
+                        }
+
+                        // Lookup role id by name in roles array
+                        $newRole = $availableRoles[strtolower($role)];
+                        $res[$key]['actions'][$action][] = $newRole;
+                    }
+                }
+            }
+        }
+
+        return $res;
+    }
+}

--- a/src/Utility/Utility.php
+++ b/src/Utility/Utility.php
@@ -27,6 +27,26 @@ class Utility {
 		return $res;
 	}
 
+    /**
+     * Returns the found INI file(s) as an array.
+     *
+     * @param array|string|null $paths Paths to look for INI files.
+     * @param string $file INI file name.
+     * @return array List with all found files.
+     */
+    public static function parseFiles($paths, $file) {
+        if ($paths === null) {
+            $paths = ROOT . DS . 'config' . DS;
+        }
+
+        $list = [];
+        foreach ((array)$paths as $path) {
+            $list += self::parseFile($path . $file);
+        }
+
+        return $list;
+    }
+
 	/**
 	 * Returns the ini file as an array.
 	 *

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -7,6 +7,7 @@ use Cake\Core\Plugin;
 use Cake\Network\Request;
 use Cake\TestSuite\TestCase;
 use ReflectionClass;
+use TestApp\Auth\AclAdapter\CustomAclAdapter;
 use TestApp\Auth\TestTinyAuthorize;
 
 /**
@@ -71,6 +72,29 @@ class TinyAuthorizeTest extends TestCase {
 		$this->assertEquals('AuthRoles', $object->getConfig('rolesTable'));
 		$this->assertEquals('auth_role_id', $object->getConfig('roleColumn'));
 	}
+
+    /**
+     * Tests loading a valid, custom acl adapter works.
+     *
+     * @return void
+     */
+	public function testLoadingAclAdapter() {
+	    $object = new TestTinyAuthorize($this->collection, [
+	        'aclAdapter' => CustomAclAdapter::class
+        ]);
+	    $this->assertInstanceOf(CustomAclAdapter::class, $object->getAclAdapter());
+    }
+
+    /**
+     * Tests loading an invalid acl adapter fails.
+     *
+     * @expectedException \Cake\Core\Exception\Exception
+     */
+    public function testLoadingInvalidAclAdapter() {
+	    $object = new TestTinyAuthorize($this->collection, [
+	        'aclAdapter' => Configure::class
+        ]);
+    }
 
 	/**
 	 * Tests exception thrown when Cache is unavailable.

--- a/tests/TestCase/Auth/TinyAuthorizeTest.php
+++ b/tests/TestCase/Auth/TinyAuthorizeTest.php
@@ -88,11 +88,22 @@ class TinyAuthorizeTest extends TestCase {
     /**
      * Tests loading an invalid acl adapter fails.
      *
-     * @expectedException \Cake\Core\Exception\Exception
+     * @expectedException \InvalidArgumentException
      */
     public function testLoadingInvalidAclAdapter() {
 	    $object = new TestTinyAuthorize($this->collection, [
 	        'aclAdapter' => Configure::class
+        ]);
+    }
+
+    /**
+     * Tests setting a non-existent class as the acl adapter fails.
+     *
+     * @expectedException \Cake\Core\Exception\Exception
+     */
+    public function testLoadingNonExistentAclAdapter() {
+        $object = new TestTinyAuthorize($this->collection, [
+            'aclAdapter' => 'Non\\Existent\\Acl\\Adapter'
         ]);
     }
 

--- a/tests/test_app/Auth/AclAdapter/CustomAclAdapter.php
+++ b/tests/test_app/Auth/AclAdapter/CustomAclAdapter.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TestApp\Auth\AclAdapter;
+
+use TinyAuth\Auth\AclAdapter\AclAdapterInterface;
+
+class CustomAclAdapter implements AclAdapterInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getAcl($availableRoles, $tinyConfig)
+    {
+        return [];
+    }
+}

--- a/tests/test_app/Auth/TestTinyAuthorize.php
+++ b/tests/test_app/Auth/TestTinyAuthorize.php
@@ -7,6 +7,13 @@ use TinyAuth\Auth\TinyAuthorize;
 
 class TestTinyAuthorize extends TinyAuthorize {
 
+    /**
+     * @return null|\TinyAuth\Auth\AclAdapter\AclAdapterInterface
+     */
+    public function getAclAdapter() {
+        return $this->_aclAdapter;
+    }
+
 	/**
 	 * @return array
 	 */


### PR DESCRIPTION
This extends `AclTrait::_getAcl()` to allow custom acl adapters for use with multiple data sources.